### PR TITLE
Group CodeQL action Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,3 +55,7 @@ updates:
     directory: /
     schedule:
       interval: daily
+    groups:
+      codeql-action:
+        patterns:
+          - github/codeql-action


### PR DESCRIPTION
### Motivation
- Consolidate Dependabot updates for the `github/codeql-action` workflow so CodeQL action version bumps are grouped in the root GitHub Actions configuration.

### Description
- Add a `groups` entry named `codeql-action` with `patterns: - github/codeql-action` under the root GitHub Actions update entry in `/.github/dependabot.yml`.

### Testing
- Ran a `python3` assertion that reads `/.github/dependabot.yml` and verified the `codeql-action` group configuration is present, and the assertion succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50ef3c3e5083258507d9289d7ed531)